### PR TITLE
fix: update framer-motion to v11 for React 19 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react-dom": "^19.1.9",
         "axios": "^1.6.2",
         "date-fns": "^2.30.0",
-        "framer-motion": "^10.16.16",
+        "framer-motion": "^11.18.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-icons": "^4.12.0",
@@ -2386,6 +2386,7 @@
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
       }
@@ -2395,7 +2396,8 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -8505,21 +8507,24 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
-      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
       "license": "MIT",
       "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
         "tslib": "^2.4.0"
       },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -11627,6 +11632,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "web-vitals": "^2.1.4",
     "axios": "^1.6.2",
     "react-icons": "^4.12.0",
-    "framer-motion": "^10.16.16",
+    "framer-motion": "^11.18.0",
     "date-fns": "^2.30.0"
   },
   "scripts": {


### PR DESCRIPTION
Fixes #12

## Summary

- Updated framer-motion from ^10.16.16 to ^11.18.0 to support React 19
- Resolves dependency conflict that was causing npm install failures
- Fixes CI/CD pipeline errors

## Changes

- `package.json`: Updated framer-motion version
- `package-lock.json`: Updated with new dependency tree

Generated with [Claude Code](https://claude.ai/code)