### PR TITLE
Fix failing App.test.tsx

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,6 @@ import App from './App';
 test('renders App component with loading state', () => {
   render(<App />);
   // The app should initially show the loading spinner for lazy-loaded components
-  const loadingElement = screen.getByText(/loading/i);
+  const loadingElement = screen.getByText(/Loading.../i);
   expect(loadingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
Fixes #16

## Summary
Fixed the failing test in App.test.tsx that was causing CI to fail.

## Changes
- Updated the regex pattern to match the actual loading text ("Loading..." instead of "loading")

## Test Results
The test now correctly matches the loading state text rendered by the App component.

Generated with [Claude Code](https://claude.ai/code)