### PR TITLE
Fix test failures in api, VideoPlayer, and PageErrorBoundary tests

### DIFF
--- a/src/__tests__/VideoPlayer.test.tsx
+++ b/src/__tests__/VideoPlayer.test.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import VideoPlayer from '../components/VideoPlayer';
 
-// Mock the videoSanitizer utils
+// Define mock functions before using them
 const mockSanitizeVideo = jest.fn();
 const mockGetSecureEmbedUrl = jest.fn();
 
 jest.mock('../utils/videoSanitizer', () => ({
-  sanitizeVideo: mockSanitizeVideo,
-  getSecureEmbedUrl: mockGetSecureEmbedUrl
+  sanitizeVideo: (...args: any[]) => mockSanitizeVideo(...args),
+  getSecureEmbedUrl: (...args: any[]) => mockGetSecureEmbedUrl(...args)
 }));
+
+// Import VideoPlayer after mock is set up
+import VideoPlayer from '../components/VideoPlayer';
 
 describe('VideoPlayer Component', () => {
   const mockVideo = {

--- a/src/components/__tests__/PageErrorBoundary.test.tsx
+++ b/src/components/__tests__/PageErrorBoundary.test.tsx
@@ -84,26 +84,21 @@ describe('PageErrorBoundary', () => {
   });
 
   it('should reset error state when Try Again is clicked', () => {
-    let shouldThrow = true;
-    
-    const { rerender } = render(
+    const TestComponent = ({ shouldThrow }: { shouldThrow: boolean }) => (
       <PageErrorBoundary>
         <ThrowError shouldThrow={shouldThrow} />
       </PageErrorBoundary>
     );
+
+    const { rerender } = render(<TestComponent shouldThrow={true} />);
 
     expect(screen.getByText('Oops! Something went wrong')).toBeInTheDocument();
 
-    // Update the flag and click Try Again
-    shouldThrow = false;
+    // Click Try Again to reset the error boundary state
     fireEvent.click(screen.getByText('Try Again'));
 
-    // The error boundary should now show the child content
-    rerender(
-      <PageErrorBoundary>
-        <ThrowError shouldThrow={shouldThrow} />
-      </PageErrorBoundary>
-    );
+    // Rerender with shouldThrow=false to show the non-error content
+    rerender(<TestComponent shouldThrow={false} />);
 
     expect(screen.getByText('No error')).toBeInTheDocument();
   });

--- a/src/config/__tests__/api.test.ts
+++ b/src/config/__tests__/api.test.ts
@@ -23,13 +23,25 @@ const mockApiClient = {
   interceptors: mockInterceptors
 };
 
-jest.mock('axios', () => ({
-  defaults: {
-    timeout: 10000,
-    withCredentials: true
-  },
-  create: jest.fn(() => mockApiClient)
-}));
+jest.mock('axios', () => {
+  // Return the mock directly without referencing mockApiClient
+  return {
+    defaults: {
+      timeout: 10000,
+      withCredentials: true
+    },
+    create: jest.fn(() => ({
+      defaults: {
+        timeout: 10000,
+        withCredentials: true,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      },
+      interceptors: mockInterceptors
+    }))
+  };
+});
 
 // Import apiClient after mocking
 import apiClient from '../api';


### PR DESCRIPTION
Fixes #24

## Summary
- Fixed circular reference in api.test.ts mock initialization
- Fixed mock function initialization order in VideoPlayer.test.tsx
- Fixed PageErrorBoundary test reset logic

Generated with [Claude Code](https://claude.ai/code)